### PR TITLE
Treat an empty KMA .res file as NULL when merging mapping results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.1.0dev
+
+### `Fixed`
+
+- Fix null KMA mapping results in `.res` file breaking MERGE_MAPPING_RESULTS process (https://github.com/OLC-Bioinformatics/BaitCapture/issues/17)
+
 ## v2.0.0 'Victoria' - [2024-05-24]
 
 ### `Added`

--- a/bin/merge-mapping-results.R
+++ b/bin/merge-mapping-results.R
@@ -228,6 +228,10 @@ if (!is.null(kma_res_file)) {
     relocate(seqlen, .after = target) |> 
     rename_with(.cols = score:p_value,
                 .fn = ~ paste("kma", .x, sep = "_"))
+  if (nrow(kma_res) == 0) {
+    print("No results found in the input KMA .res file.")
+    kma_res_file = NULL
+  }
 }
 
 if (!is.null(target_metadata_file)) {


### PR DESCRIPTION
<!--
# BaitCapture pull request

Many thanks for contributing to BaitCapture!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/OLC-Bioinformatics/BaitCapture/blob/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] `CHANGELOG.md` is updated.

## Description

This PR fixes https://github.com/OLC-Bioinformatics/BaitCapture/issues/17 where MERGE_MAPPING_RESULTS fails if there are no results in the KMA `.res` file for a sample after alignment.
