### PR TITLE
Check for duplicated rows in `--input` samplesheet.csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Fix nf-schema plugin not checking for unique sample IDs when a samplesheet is provided with `--input` (https://github.com/OLC-Bioinformatics/BaitCapture/issues/15)
 - Fix null KMA mapping results in `.res` file breaking MERGE_MAPPING_RESULTS process (https://github.com/OLC-Bioinformatics/BaitCapture/issues/17)
 
 ## v2.0.0 'Victoria' - [2024-05-24]

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -10,7 +10,6 @@
             "sample": {
                 "type": "string",
                 "pattern": "^[a-zA-Z][a-zA-Z0-9_]+$",
-                "unique": ["sample"],
                 "errorMessage": "Unique sample ID must be provided: Must start with a letter, and can only contain letters, numbers or underscores; Regex: '^[a-zA-Z][a-zA-Z0-9_]+$'",
                 "meta": ["id"]
             },

--- a/subworkflows/local/parse_input.nf
+++ b/subworkflows/local/parse_input.nf
@@ -21,7 +21,7 @@ workflow PARSE_INPUT {
                 [ meta, reads ] }
         .set { ch_reads }
     
-    //Check whether all sampleID = meta.id are unique
+    //Check whether all sample = meta.id are unique
     ch_reads
         .map { meta, reads -> [ meta.id ] }
         .toList()

--- a/workflows/baitcapture.nf
+++ b/workflows/baitcapture.nf
@@ -84,6 +84,16 @@ workflow BAITCAPTURE {
                 def reads = [fastq_1, fastq_2]
                 return [meta, reads]
             }
+            //Check whether all sample = meta.id are unique
+            ch_reads
+                .map { meta, reads -> [ meta.id ] }
+                .toList()
+                .subscribe {
+                    if( it.size() != it.unique().size() ) {
+                        ids = it.take(10);
+                        error("Please review data input, sample IDs are not unique! First IDs are $ids")
+                    }
+                }
     } else if (params.input_folder) {
         PARSE_INPUT(params.input_folder, params.pattern)
         ch_reads = PARSE_INPUT.out.reads


### PR DESCRIPTION
## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] `CHANGELOG.md` is updated.

This PR fixes https://github.com/OLC-Bioinformatics/BaitCapture/issues/15 where SUMMARIZE_STATS fails if there are duplicated sample IDs provided in the samplesheet with `--input`. The workflow will now fail verbosely immediately after the samplesheet is read if there are duplicated sample IDs.